### PR TITLE
Do not change link styles in the custom content element

### DIFF
--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -93,18 +93,20 @@ body.hc-nav-open {
     cursor: pointer;
   }
 
-  a {
-    position: relative;
-    display: block;
-    box-sizing: border-box;
-    cursor: pointer;
+  li:not(.custom-content) {
+    a {
+      position: relative;
+      display: block;
+      box-sizing: border-box;
+      cursor: pointer;
 
-    &,
-    &:hover {
-      text-decoration: none;
+      &,
+      &:hover {
+        text-decoration: none;
+      }
     }
   }
-
+  
   .nav-item {
     position: relative;
     display: block;


### PR DESCRIPTION
By default, all links in the `custom content` element have display: block and few additional styles. I think that links in the `custom content` element should inherit global styles from the website. 