### PR TITLE
Use div instead of h2 in nav-title to meet the SEO requirement that h1 should always be the first header

### DIFF
--- a/src/js/hc-offcanvas-nav.js
+++ b/src/js/hc-offcanvas-nav.js
@@ -571,7 +571,7 @@
               ? title
               : Helpers.clone(window.jQuery && title instanceof window.jQuery && title.length ? title[0] : title, true, true);
 
-            $content.insertBefore(Helpers.createElement('h2', {
+            $content.insertBefore(Helpers.createElement('div', {
               id: level === 0 ? `${navUniqId}-nav-title` : null,
               class: level === 0 ? 'nav-title' : 'level-title'
             }, _title), $content.firstChild);

--- a/src/scss/_theme-carbon.scss
+++ b/src/scss/_theme-carbon.scss
@@ -22,7 +22,7 @@ $hc-offcanvas-nav-text-size:          15px !default;
     padding: 0 15px;
 
     & > {
-      h2, h3, h4, h5, h6 {
+      div {
         font-size: round($hc-offcanvas-nav-text-size * 1.26);
         font-weight: normal;
         padding: 25px 15px 30px;
@@ -224,7 +224,7 @@ $hc-offcanvas-nav-text-size:          15px !default;
           }
 
           & + {
-            h2, h3, h4, h5, h6 {
+            div {
               margin-top: 55px;
             }
           }

--- a/src/scss/_theme-default.scss
+++ b/src/scss/_theme-default.scss
@@ -19,7 +19,7 @@ $hc-offcanvas-nav-text-size:          14px !default;
   }
 
   .nav-content > {
-    h2, h3, h4, h5, h6 {
+    div {
       font-size: round($hc-offcanvas-nav-text-size * 1.35);
       font-weight: normal;
       padding: 20px 17px;
@@ -106,13 +106,13 @@ $hc-offcanvas-nav-text-size:          14px !default;
         }
 
         & + {
-          h2, h3, h4, h5, h6 {
+          div {
             margin-top: -2px;
           }
         }
       }
 
-      h2, h3, h4, h5, h6 {
+      div {
         & + ul {
           & > li {
             &:first-child:not(.nav-back):not(.nav-close) {
@@ -130,7 +130,7 @@ $hc-offcanvas-nav-text-size:          14px !default;
       .level-title,
       .nav-close {
         & + {
-          h2, h3, h4, h5, h6 {
+          div {
             border-top: 1px solid darken($hc-offcanvas-nav-background-color, 6%);
           }
         }


### PR DESCRIPTION
Hi, 

Thanks for developing this lovely library ! It is very useful.

While using it I realized that it adds some questionable h2 elements. What's the reasoning here ? How to ensure that  these h2 meet SEO requirements ? SEO requires that h2 (if any) should be after a h1. 
Currently, it seems that h2s introduced by the library may be placed before the h1 of the initial html file.

In fact, it seems that these h2s are not necessary : the html content of the page will already contain h1, h2, ... And the user of the library may want to be the only one to choose where to write h1, h2, ... elements.

Please find a PR suggestion where I have replaced -- in js and scss files --  all h2, h3, ... with a simple div.