### PR TITLE
Replace the release link with the tags link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This package can be installed with:
 
 - [npm](https://www.npmjs.com/package/hc-offcanvas-nav): `npm install --save hc-offcanvas-nav`
 
-Or download the [latest release](https://github.com/somewebmedia/hc-offcanvas-nav/releases).
+Or download the [latest release](https://github.com/somewebmedia/hc-offcanvas-nav/tags).
 
 
 


### PR DESCRIPTION
Reason: At the moment you have no releases. Only tags.